### PR TITLE
商品一覧表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -3,7 +3,7 @@ class ItemsController < ApplicationController
   before_action :set_login, only: [:new]
 
   def index
-    @items = Item.all.order(id: "DESC")
+    @items = Item.all.order(id: 'DESC')
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,9 @@
 class ItemsController < ApplicationController
+  before_action :authenticate_user!, except: [:index]
   before_action :set_login, only: [:new]
+
   def index
+    @items = Item.all.order(id: "DESC")
   end
 
   def new
@@ -10,7 +13,7 @@ class ItemsController < ApplicationController
   def create
     @item = Item.new(item_params)
     if @item.save
-      redirect_to :root
+      redirect_to root_path
     else
       render :new
     end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,0 +1,2 @@
+class Order < ApplicationRecord
+end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,2 +1,4 @@
 class Order < ApplicationRecord
+  belongs_to :item
+  belongs_to :user
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -127,7 +127,6 @@
     <ul class='item-lists'>
 
     <% @items.each do |item|%>
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
       <li class='list'>
         <%= link_to item_path(item) do %>
         <div class='item-img-content'>
@@ -154,13 +153,10 @@
         </div>
         <% end %>
       </li>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
       <% end %>
     </ul>
   </div>
-  <%# //商品一覧 %>
 </div>
-<%# //商品出品ページへのリンクはログイン時のみ表示 %>
 <% if user_signed_in? %>
   <%= link_to new_item_path do %>
     <div class='purchase-btn'>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -123,28 +123,29 @@
   <%# 商品一覧 %>
   <div class='item-contents'>
     <h2 class='title'>ピックアップカテゴリー</h2>
-    <%= link_to '新規投稿商品', "items/new", class: "subtitle" %>
+    <%= link_to '新規投稿商品', "#", class: "subtitle" %>
     <ul class='item-lists'>
 
+    <% @items.each do |item|%>
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
       <li class='list'>
-        <%= link_to "#" do %>
+        <%= link_to item_path(item) do %>
         <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+          <%= image_tag item.image, class: "item-img" %>
 
-          <%# 商品が売れていればsold outの表示 %>
+          <% if item.order != nil  %>
           <div class='sold-out'>
             <span>Sold Out!!</span>
           </div>
-          <%# //商品が売れていればsold outの表示 %>
+          <% end %>
 
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= "商品名" %>
+            <%= item.name %>
           </h3>
           <div class='item-price'>
-            <span><%= "販売価格" %>円<br>(税込み)</span>
+            <span><%= item.price %>円<br>(税込み)</span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
@@ -154,36 +155,18 @@
         <% end %>
       </li>
       <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-
-      <%# 商品がない場合のダミー %>
-      <%# 商品がある場合は表示されないようにしましょう %>
-      <li class='list'>
-        <%= link_to '#' do %>
-        <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            商品を出品してね！
-          </h3>
-          <div class='item-price'>
-            <span>99999999円<br>(税込み)</span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
-            </div>
-          </div>
-        </div>
-        <% end %>
-      </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# //商品がない場合のダミー %>
+      <% end %>
     </ul>
   </div>
   <%# //商品一覧 %>
 </div>
-<div class='purchase-btn'>
-  <span class='purchase-btn-text'>出品する</span>
-  <a href="items/new">
-    <%= image_tag 'camera.png' , size: '185x50' ,class: "purchase-btn-icon" %>
-  </a>
-</div>
+<%# //商品出品ページへのリンクはログイン時のみ表示 %>
+<% if user_signed_in? %>
+  <%= link_to new_item_path do %>
+    <div class='purchase-btn'>
+      <span class='purchase-btn-text'>出品する</span>
+        <%= image_tag 'camera.png' , size: '185x50' ,class: "purchase-btn-icon" %>
+    </div>
+  <% end %>
+<% end %>
 <%= render "shared/footer" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
-  resource :items
+  resources :items
   root to: 'items#index'
 end

--- a/db/migrate/20200809163209_create_orders.rb
+++ b/db/migrate/20200809163209_create_orders.rb
@@ -1,0 +1,8 @@
+class CreateOrders < ActiveRecord::Migration[6.0]
+  def change
+    create_table :orders do |t|
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200809163209_create_orders.rb
+++ b/db/migrate/20200809163209_create_orders.rb
@@ -1,7 +1,8 @@
 class CreateOrders < ActiveRecord::Migration[6.0]
   def change
     create_table :orders do |t|
-
+      t.references :user,             null: false,foreign_key: true
+      t.references :item,             null: false,foreign_key: true
       t.timestamps
     end
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_09_072819) do
+ActiveRecord::Schema.define(version: 2020_08_09_163209) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -47,6 +47,15 @@ ActiveRecord::Schema.define(version: 2020_08_09_072819) do
     t.index ["user_id"], name: "index_items_on_user_id"
   end
 
+  create_table "orders", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "item_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["item_id"], name: "index_orders_on_item_id"
+    t.index ["user_id"], name: "index_orders_on_user_id"
+  end
+
   create_table "scheduled_deliveries", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
@@ -72,4 +81,6 @@ ActiveRecord::Schema.define(version: 2020_08_09_072819) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "items", "users"
+  add_foreign_key "orders", "items"
+  add_foreign_key "orders", "users"
 end

--- a/spec/factories/orders.rb
+++ b/spec/factories/orders.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :order do
+    
+  end
+end

--- a/spec/factories/orders.rb
+++ b/spec/factories/orders.rb
@@ -1,5 +1,4 @@
 FactoryBot.define do
   factory :order do
-    
   end
 end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Order, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
# 実装概要
出品された商品をトップページで一覧で表示されるよう実装。

# 実装条件
- 画像が表示されており、画像がリンク切れなどになっていないこと
- 出品した商品の一覧表示ができている。かつ「画像/価格/商品名」の3つの情報について表示できていること
- 売却済みの商品は、「sold out」の文字が表示されるようになっていること
- ログアウト状態でも商品一覧ページを見ることができること

# 補足情報
- （キャプチャ）出品した商品の一覧表示ができている。かつ「画像/価格/商品名」の3つの情報について表示できていること（追加で出品の新しい順に並び替え）
https://gyazo.com/ad3623fcad5dec5602531438053e74ea
シークエルプロ の中身
https://gyazo.com/93733df4117e0f52bb1f793436cd4413

- （キャプチャ）ログアウト状態でも商品一覧ページを見ることができること
https://gyazo.com/0cab1f8b65dd2004b2c95ca99785a7e6
