### PR TITLE
商品詳細表示機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, except: [:index]
+  before_action :authenticate_user!, except: [:index, :show]
   before_action :set_login, only: [:new]
 
   def index
@@ -17,6 +17,10 @@ class ItemsController < ApplicationController
     else
       render :new
     end
+  end
+
+  def show
+    @item = Item.find_by(id: params[:id])
   end
 
   private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
   before_action :set_login, only: [:new]
+  before_action :set_item, only: [:show]
 
   def index
     @items = Item.all.order(id: 'DESC')
@@ -20,10 +21,13 @@ class ItemsController < ApplicationController
   end
 
   def show
-    @item = Item.find_by(id: params[:id])
   end
 
   private
+
+  def set_item
+    @item = Item.find_by(id: params[:id])
+  end
 
   def item_params
     params.require(:item).permit(:image, :name, :info, :category_id, :sales_status_id, :shipping_fee_status_id, :prefecture_id, :scheduled_delivery_id, :price).merge(user_id: current_user.id)

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -35,7 +35,7 @@
     <% end %>  
 
     <% if @item.order == nil && (!user_signed_in? || @item.user != current_user) %>
-      <%= link_to '購入画面に進む', item_transactions_path(@item), class:"item-red-btn"%>
+      <%= link_to '購入画面に進む', '#', class:"item-red-btn"%>
     <% end %>
 
     <div class="item-explain-box">

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -28,14 +28,12 @@
       </span>
     </div>
 
-    <%# ログインしていて、なおかつ、ログインしているユーザと出品しているユーザが同一人物でないときの表示 %>
     <% if @item.user == current_user %>
       <%= link_to '商品の編集', edit_item_path(@item), method: :get, class: "item-red-btn" %>
       <p class='or-text'>or</p>
       <%= link_to '削除', item_path(@item), method: :delete, class:'item-destroy' %>
     <% end %>  
 
-    <%# 商品が売れていない場合 %>
     <% if @item.order == nil && (!user_signed_in? || @item.user != current_user) %>
       <%= link_to '購入画面に進む', item_transactions_path(@item), class:"item-red-btn"%>
     <% end %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -35,11 +35,10 @@
       <%= link_to '削除', item_path(@item), method: :delete, class:'item-destroy' %>
     <% end %>  
 
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
-
-    <%# //ログインしていて、なおかつ、ログインしているユーザと出品しているユーザが同一人物でないとき表示しましょう。 %>
+    <%# 商品が売れていない場合 %>
+    <% if @item.order == nil && (!user_signed_in? || @item.user != current_user) %>
+      <%= link_to '購入画面に進む', item_transactions_path(@item), class:"item-red-btn"%>
+    <% end %>
 
     <div class="item-explain-box">
       <span><%= @item.info %></span>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -28,11 +28,12 @@
       </span>
     </div>
 
-    <%# ログインしていて、なおかつ、ログインしているユーザと出品しているユーザが同一人物でないとき表示 %>
-
-    <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
-    <p class='or-text'>or</p>
-    <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
+    <%# ログインしていて、なおかつ、ログインしているユーザと出品しているユーザが同一人物でないときの表示 %>
+    <% if @item.user == current_user %>
+      <%= link_to '商品の編集', edit_item_path(@item), method: :get, class: "item-red-btn" %>
+      <p class='or-text'>or</p>
+      <%= link_to '削除', item_path(@item), method: :delete, class:'item-destroy' %>
+    <% end %>  
 
     <%# 商品が売れていない場合はこちらを表示しましょう %>
     <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,26 +4,31 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.name %>
     </h2>
     <div class='item-img-content'>
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
-      <%# 商品が売れている場合は、sould outの表示をしましょう。 %>
-      <div class='sold-out'>
-        <span>Sold Out!!</span>
-      </div>
-      <%# //商品が売れている場合は、sould outの表示をしましょう。 %>
+      <%= image_tag @item.image,　class:"item-box-img" %>
+      <% if @item.order != nil %>
+        <div class='sold-out'>
+          <span>Sold Out!!</span>
+        </div>
+      <% end %>
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        ¥<%= @item.price %>
       </span>
       <span class="item-postage">
-        (税込) 送料込み
+        (税込) 
+        <% if @item.shipping_fee_status_id == 2 %>
+        送料別
+        <% else @item.shipping_fee_status_id == 3 %>
+        送料込み
+        <% end %>
       </span>
     </div>
 
-    <%# ログインしていて、なおかつ、ログインしているユーザと出品しているユーザが同一人物でないとき表示しましょう。 %>
+    <%# ログインしていて、なおかつ、ログインしているユーザと出品しているユーザが同一人物でないとき表示 %>
 
     <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
     <p class='or-text'>or</p>
@@ -36,33 +41,33 @@
     <%# //ログインしていて、なおかつ、ログインしているユーザと出品しているユーザが同一人物でないとき表示しましょう。 %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.info %></span>
     </div>
     <table class="detail-table">
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= Category.find(@item.category_id)[:name] %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= SalesStatus.find(@item.sales_status_id)[:name] %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= ShippingFeeStatus.find(@item.shipping_fee_status_id	)[:name] %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= Prefecture.find(@item.prefecture_id)[:name] %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= ScheduledDelivery.find(@item.scheduled_delivery_id)[:name] %></td>
         </tr>
       </tbody>
     </table>


### PR DESCRIPTION
# 実装概要
詳細ページにアクセスして商品詳細情報表示できように実装した。

# 実装条件
- ログアウト状態でも商品詳細ページを閲覧できること
- 出品者にしか商品の編集・削除のリンクが踏めないようになっていること
- 出品者以外（且つログインしたユーザー）のみ商品購入のリンクが踏めること
- 商品出品時に登録した情報が見られるようになっていること
- 画像が表示されており、画像がリンク切れなどになっていないこと

# 補足情報
- （キャプチャ）ログアウト状態でも商品詳細ページを閲覧できること。
https://gyazo.com/4f76e27b3b2511d0a71fc3e003a5b674

- 出品者にしか商品の編集・削除のリンクが踏めないようになっていること
https://gyazo.com/ccf1fb9b1ed6564765b46c0ec776a783

- 商品出品時に登録した情報が見られるようになっていること
https://gyazo.com/fa90297a1f8b11f4d0dafcaa3cd22354