### PR TITLE
商品情報編集機能の実装

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,2 +1,3 @@
 //= link_tree ../images
+//= link_directory ../javascripts .js
 //= link_directory ../stylesheets .css

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,0 +1,2 @@
+//= require jquery
+//= require rails-ujs

--- a/app/assets/javascripts/sales_commission.js
+++ b/app/assets/javascripts/sales_commission.js
@@ -1,10 +1,10 @@
 $('#price').change(function(){
-  var p = $("#price").val();
-  var pri = parseInt(p);
-  var tax = Math.trunc(pri * 0.1);
-  var pro = pri - tax;
+  let p = $("#price").val();
+  let pri = parseInt(p);
+  let tax = Math.trunc(pri * 0.1);
+  let pro = pri - tax;
 
-  var pattern =	/^[1-9][0-9]*$/;
+  let pattern =	/^[1-9][0-9]*$/;
   if (pattern.test(p)){
     taxx = tax.toLocaleString()
     prox = pro.toLocaleString()

--- a/app/assets/javascripts/sales_commission.js
+++ b/app/assets/javascripts/sales_commission.js
@@ -1,0 +1,17 @@
+$('#price').change(function(){
+  var p = $("#price").val();
+  var pri = parseInt(p);
+  var tax = Math.trunc(pri * 0.1);
+  var pro = pri - tax;
+
+  var pattern =	/^[1-9][0-9]*$/;
+  if (pattern.test(p)){
+    taxx = tax.toLocaleString()
+    prox = pro.toLocaleString()
+    $('#tax').text(taxx);
+    $('#profit').text(prox);
+  }else{
+    $('#tax').text("半角数字のみ入力可能");
+    $('#profit').text("半角数字のみ入力可能");
+  }
+});

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
   before_action :set_login, only: [:new]
-  before_action :set_item, only: [:show]
+  before_action :set_item, only: [:show, :edit, :update]
 
   def index
     @items = Item.all.order(id: 'DESC')
@@ -21,6 +21,17 @@ class ItemsController < ApplicationController
   end
 
   def show
+  end
+
+  def edit
+  end
+
+  def update
+    if @item.update(item_params)
+      redirect_to item_path(@item)
+    else
+      render :edit
+    end
   end
 
   private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -46,9 +46,7 @@ class ItemsController < ApplicationController
   end
 
   def owner?
-    if @item.user != current_user
-      redirect_to items_path
-    end
+    redirect_to items_path if @item.user != current_user
   end
 
   def set_login

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,6 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
   before_action :set_login, only: [:new]
   before_action :set_item, only: [:show, :edit, :update]
+  before_action :owner?, only: [:edit, :update]
 
   def index
     @items = Item.all.order(id: 'DESC')
@@ -42,6 +43,12 @@ class ItemsController < ApplicationController
 
   def item_params
     params.require(:item).permit(:image, :name, :info, :category_id, :sales_status_id, :shipping_fee_status_id, :prefecture_id, :scheduled_delivery_id, :price).merge(user_id: current_user.id)
+  end
+
+  def owner?
+    if @item.user != current_user
+      redirect_to items_path
+    end
   end
 
   def set_login

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -9,9 +9,7 @@ app/assets/stylesheets/items/new.css %>
     <h2 class="items-sell-title">商品の情報を入力</h2>
     <%= form_with local: true do |f| %>
 
-    <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
-    <%# render 'shared/error_messages', model: f.object %>
-    <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
+    <%= render 'shared/error_messages', model: f.object %>
 
     <%# 出品画像 %>
     <div class="img-upload">

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -156,22 +156,4 @@
   </footer>
 </div>
 
-<script type = "text/javascript">
-  $('#price').change(function(){
-    var p = $("#price").val();
-    var pri = parseInt(p);
-    var tax = Math.trunc(pri * 0.1);
-    var pro = pri - tax;
-
-    var pattern =	/^[1-9][0-9]*$/;
-    if (pattern.test(p)){
-      taxx = tax.toLocaleString()
-      prox = pro.toLocaleString()
-      $('#tax').text(taxx);
-      $('#profit').text(prox);
-    }else{
-      $('#tax').text("半角数字のみ入力可能");
-      $('#profit').text("半角数字のみ入力可能");
-    }
-  });
-</script> 
+<%= javascript_include_tag 'sales_commission.js' %>

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -97,12 +97,12 @@
             <span class="indispensable">必須</span>
           </div>
           <span class="sell-yen">¥</span>
-          <%= f.text_field :hoge, class:"price-input", placeholder:"例）300" %>
+          <%= f.text_field :price, class:"price-input", id:"price", placeholder:"例）300" %>
         </div>
         <div class="price-content">
           <span>販売手数料 (10%)</span>
           <span>
-            <span id='add-tax-price'></span>円
+            <span id='tax'></span>円
           </span>
         </div>
         <div class="price-content">
@@ -155,3 +155,23 @@
     </p>
   </footer>
 </div>
+
+<script type = "text/javascript">
+  $('#price').change(function(){
+    var p = $("#price").val();
+    var pri = parseInt(p);
+    var tax = Math.trunc(pri * 0.1);
+    var pro = pri - tax;
+
+    var pattern =	/^[1-9][0-9]*$/;
+    if (pattern.test(p)){
+      taxx = tax.toLocaleString()
+      prox = pro.toLocaleString()
+      $('#tax').text(taxx);
+      $('#profit').text(prox);
+    }else{
+      $('#tax').text("半角数字のみ入力可能");
+      $('#profit').text("半角数字のみ入力可能");
+    }
+  });
+</script> 

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -1,13 +1,11 @@
-<%# cssは商品出品のものを併用しています。
-app/assets/stylesheets/items/new.css %>
-
 <div class="items-sell-contents">
   <header class="items-sell-header">
     <%= link_to image_tag('furima-logo-color.png' , size: '185x50'), "/" %>
+
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with local: true do |f| %>
+    <%= form_with model: @item, url: item_path(@item), local: true do |f| %>
 
     <%= render 'shared/error_messages', model: f.object %>
 
@@ -21,7 +19,7 @@ app/assets/stylesheets/items/new.css %>
         <p>
           クリックしてファイルをアップロード
         </p>
-        <%= f.file_field :hoge %>
+        <%= f.file_field :image %>
       </div>
     </div>
     <%# /出品画像 %>
@@ -31,13 +29,13 @@ app/assets/stylesheets/items/new.css %>
         商品名
         <span class="indispensable">必須</span>
       </div>
-      <%= f.text_area :hoge, class:"items-text", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
+      <%= f.text_area :name, class:"items-text", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
       <div class="items-explain">
         <div class="weight-bold-text">
           商品の説明
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_area :hoge, class:"items-text", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
+        <%= f.text_area :info, class:"items-text", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
       </div>
     </div>
     <%# /商品名と商品説明 %>
@@ -50,12 +48,12 @@ app/assets/stylesheets/items/new.css %>
           カテゴリー
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box"}) %>
+        <%= f.collection_select(:category_id, Category.all, :id, :name, {}, {class:"select-box"}) %>
         <div class="weight-bold-text">
           商品の状態
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box"}) %>
+        <%= f.collection_select(:sales_status_id, SalesStatus.all, :id, :name, {}, {class:"select-box"}) %>
       </div>
     </div>
     <%# /商品の詳細 %>
@@ -71,17 +69,17 @@ app/assets/stylesheets/items/new.css %>
           配送料の負担
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box"}) %>
+        <%= f.collection_select(:shipping_fee_status_id, ShippingFeeStatus.all, :id, :name, {}, {class:"select-box"}) %>
         <div class="weight-bold-text">
           発送元の地域
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box"}) %>
+        <%= f.collection_select(:prefecture_id, Prefecture.all, :id, :name, {}, {class:"select-box"}) %>
         <div class="weight-bold-text">
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box"}) %>
+        <%= f.collection_select(:scheduled_delivery_id, ScheduledDelivery.all, :id, :name, {}, {class:"select-box"}) %>
       </div>
     </div>
     <%# /配送について %>

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -137,7 +137,7 @@
     <%# 下部ボタン %>
     <div class="sell-btn-contents">
       <%= f.submit "変更する" ,class:"sell-btn" %>
-      <%=link_to 'もどる', "#", class:"back-btn" %>
+      <%=link_to 'もどる', item_path(@item), class:"back-btn" %>
     </div>
     <%# /下部ボタン %>
   </div>

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -156,22 +156,4 @@
   </footer>
 </div>
 
-<script type = "text/javascript">
-  $('#price').change(function(){
-    var p = $("#price").val();
-    var pri = parseInt(p);
-    var tax = Math.trunc(pri * 0.1);
-    var pro = pri - tax;
-
-    var pattern =	/^[1-9][0-9]*$/;
-    if (pattern.test(p)){
-      taxx = tax.toLocaleString()
-      prox = pro.toLocaleString()
-      $('#tax').text(taxx);
-      $('#profit').text(prox);
-    }else{
-      $('#tax').text("半角数字のみ入力可能");
-      $('#profit').text("半角数字のみ入力可能");
-    }
-  });
-</script> 
+<%= javascript_include_tag 'sales_commission.js' %>

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -12,3 +12,5 @@ Rails.application.config.assets.paths << Rails.root.join('node_modules')
 # application.js, application.css, and all non-JS/CSS in the app/assets
 # folder are already added.
 # Rails.application.config.assets.precompile += %w( admin.js admin.css )
+
+Rails.application.config.assets.precompile += %w( sales_commission.js )


### PR DESCRIPTION
# 実装概要
画像を含む商品の情報を編集する機能を実装した。

# 実装条件
- 商品情報（商品画像・商品名・商品の状態など）を変更できること
- 出品者だけが編集ページに遷移できること
- 商品出品時とほぼ同じUIで編集機能が実装できること
- 商品名やカテゴリーの情報など、すでに登録されている商品情報は編集画面を開いた時点で表示されること
- エラーハンドリングができていること

# 補足情報
- [キャプチャ]商品情報（商品画像・商品名・商品の状態など）を変更できること
https://gyazo.com/c226ad044ca36199ef59c06b2f76d09a

- [キャプチャ]エラーハンドリングができていること
https://gyazo.com/aee530dfa4ccd2a97b6f1a1ac5b0e468