### PR TITLE
商品削除機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,8 +1,8 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
   before_action :set_login, only: [:new]
-  before_action :set_item, only: [:show, :edit, :update]
-  before_action :owner?, only: [:edit, :update]
+  before_action :set_item, only: [:show, :edit, :update,:destroy]
+  before_action :owner?, only: [:edit, :update, :destroy]
 
   def index
     @items = Item.all.order(id: 'DESC')
@@ -32,6 +32,14 @@ class ItemsController < ApplicationController
       redirect_to item_path(@item)
     else
       render :edit
+    end
+  end
+
+  def destroy
+    if @item.destroy
+      redirect_to items_path
+    else
+      render item_path(@item)
     end
   end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
   before_action :set_login, only: [:new]
-  before_action :set_item, only: [:show, :edit, :update,:destroy]
+  before_action :set_item, only: [:show, :edit, :update, :destroy]
   before_action :owner?, only: [:edit, :update, :destroy]
 
   def index


### PR DESCRIPTION
# 実装概要
商品の情報を削除する機能を実装した。

# 実装の条件
- 出品者だけが商品情報を削除できること

# 補足情報
- 出品者だけが商品情報を削除できること
https://gyazo.com/8320403ef21c0e3a0b15b09315cbb487

-viewに記述する削除の際のpathは商品詳細表示機能実装時に記述済。